### PR TITLE
Remove ancillary output messaging from echo step

### DIFF
--- a/steps/curl/step.yaml
+++ b/steps/curl/step.yaml
@@ -52,11 +52,11 @@ examples:
         headers:
           "Content-Type": "application/json"
           Accept: "application/json"
-          Authorization: !Secret secret
+          Authorization: ${secrets.auth}
         body:
-          name: !Parameter name
-          environmentId: !Parameter environment
-          workspaceId: !Parameter workspace
+          name: ${parameters.name}
+          environmentId: ${parameters.environment}
+          workspaceId: ${parameters.workspace}
 
 schemas:
   outputs:

--- a/steps/echo/step.sh
+++ b/steps/echo/step.sh
@@ -2,4 +2,4 @@
 set -euo pipefail
 
 MESSAGE=$(ni get -p '{.message}')
-echo "Your message was: $MESSAGE"
+echo "${MESSAGE}"

--- a/steps/echo/step.yaml
+++ b/steps/echo/step.yaml
@@ -4,7 +4,7 @@ name: echo
 version: 1
 summary: Echo a message
 description: |
-  This step echoes a message that is provided as a parameter
+  This step echoes a provided message
 build:
   apiVersion: build/v1
   kind: Docker

--- a/triggers/json/trigger.yaml
+++ b/triggers/json/trigger.yaml
@@ -4,7 +4,7 @@ name: json
 version: 1
 summary: Receive a webhook
 description: |
-  This trigger receives a generic webhook and passes through a JSON object 
+  This trigger receives a generic webhook and passes through a JSON object
   sent as an HTTP request body as Relay event.
 
 responders:
@@ -27,7 +27,7 @@ examples:
       image: relaysh/stdlib-trigger-json
     binding:
       parameters:
-        foo: !Data foo
+        foo: ${event.foo}
 
 build:
   apiVersion: build/v1


### PR DESCRIPTION
* Removes the "Your message was:"  ancillary messaging from the echo step
  * Echo is expected to echo the message provided, and adding additional context is not desirable for many reasons
  * Additionally, it also gives the impression of being a debug/diagnostic step, which is not the intention (and the tone of it is a bit too familiar as well)
* Updates examples to use the new expression language