### PR TITLE
Update schema so that failon and expects use arrays

### DIFF
--- a/steps/curl/spec.schema.json
+++ b/steps/curl/spec.schema.json
@@ -32,11 +32,11 @@
         "description": "The optional query parameters to add to the request"
       },
       "expects": {
-        "type": "object",
+        "type": "array",
         "description": "The optional http code(s) required for the step to succeed"
       },
       "failon": {
-        "type": "object",
+        "type": "array",
         "description": "The optional http code(s) that will always make the step fail"
       },
       "git": {

--- a/steps/curl/step.yaml
+++ b/steps/curl/step.yaml
@@ -28,7 +28,7 @@ examples:
       spec:
         method: GET
         url: "https://random.justyy.workers.dev/api/random/"
-        expects: 200
+        expects: [ 200 ]
         query:
           n: 32
           x: 1


### PR DESCRIPTION
The previous schema has objects for the failon and expect error
parameters but jq could not translate these object for the shell.
These should instead each accept an array of error codes.